### PR TITLE
Add stock model and portfolio view

### DIFF
--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/Gemfile
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/Gemfile
@@ -38,6 +38,9 @@ gem 'jbuilder', '~> 2.5'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Get stock quotes
+gem 'stock_quote'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/Gemfile.lock
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/Gemfile.lock
@@ -70,15 +70,20 @@ GEM
       responders
       warden (~> 1.2.3)
     devise-bootstrap-views (0.0.11)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.6.1)
     execjs (2.7.0)
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (0.8.6)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    json (2.1.0)
     less (2.6.0)
       commonjs (~> 0.2.7)
     less-rails (2.8.0)
@@ -102,6 +107,7 @@ GEM
     mini_portile2 (2.2.0)
     minitest (5.10.3)
     multi_json (1.12.2)
+    netrc (0.11.0)
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
@@ -141,6 +147,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     sass (3.5.1)
@@ -170,6 +180,9 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    stock_quote (1.4.0)
+      json
+      rest-client (~> 2.0.2)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -185,6 +198,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (3.5.1)
@@ -216,6 +232,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
+  stock_quote
   turbolinks (~> 5)
   twitter-bootstrap-rails
   tzinfo-data

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/app/controllers/users_controller.rb
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/app/controllers/users_controller.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def my_portfolio
+  end
+end

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/app/models/stock.rb
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/app/models/stock.rb
@@ -1,0 +1,2 @@
+class Stock < ApplicationRecord
+end

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/app/views/users/my_portfolio.html.erb
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/app/views/users/my_portfolio.html.erb
@@ -1,0 +1,1 @@
+<h1>Portfolio</h1>

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/config/routes.rb
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'welcome#index'
+  get 'my_portfolio', to: "users#my_portfolio"
 end

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/db/migrate/20170913174738_create_stocks.rb
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/db/migrate/20170913174738_create_stocks.rb
@@ -1,0 +1,11 @@
+class CreateStocks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :stocks do |t|
+      t.string :ticker
+      t.string :name
+      t.decimal :last_price
+
+      t.timestamps
+    end
+  end
+end

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/db/schema.rb
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170913152255) do
+ActiveRecord::Schema.define(version: 20170913174738) do
+
+  create_table "stocks", force: :cascade do |t|
+    t.string "ticker"
+    t.string "name"
+    t.decimal "last_price"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/test/fixtures/stocks.yml
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/test/fixtures/stocks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  ticker: MyString
+  name: MyString
+  last_price: 9.99
+
+two:
+  ticker: MyString
+  name: MyString
+  last_price: 9.99

--- a/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/test/models/stock_test.rb
+++ b/Udemy Rails Course/Section 8 - Finance Tracker/FinanceTrackerApp/test/models/stock_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StockTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
**Notes:**
- `rails g model Stock ticker:string name:string last_price:decimal` Generate the stock model.
- Since `devise_for :users` handled the users controller, we need to create a users controller because now we are trying to route to a portfolio page, which is not handled by the devise gem.

**Using the StockQuote gem:**
- `StockQuote::Stock.quote('GOOG’)` Look up a stock by name and see all available attributes with values.
- `StockQuote::Stock.quote('GOOG').close` See the closing price of a stock. Will be nil if the day is not over.
- `previous_close` Yesterdays closing price.
- `open` Today's opening price.